### PR TITLE
Remove `println!` from software fallback

### DIFF
--- a/src/arch/software.rs
+++ b/src/arch/software.rs
@@ -113,12 +113,6 @@ fn update_u32(state: u32, data: &[u8], params: crc::Crc<u32, Table<16>>) -> u32 
 
     let checksum = digest.finalize();
 
-    println!(
-        "finalized checksum  {:#16x}, xor'd {:#16x}",
-        checksum,
-        checksum ^ params.algorithm.xorout
-    );
-
     // remove XOR since this will be applied in the library Digest::finalize() step instead
     checksum ^ params.algorithm.xorout
 }


### PR DESCRIPTION
## The Problem

Fixing https://github.com/awesomized/crc-fast-rust/issues/3, the software fallback was unconditionally using `println!()`, so logging for all consumers

## The Solution

I removed that log.

### Changes

[ A more detailed explanation of the solution to guide reviewers. Point out tricky or magic areas. ]

### Planned version bump

- Which: [ `PATCH` ]
- Why: [ non-breaking bug fix ]

### Links

* https://github.com/awesomized/crc-fast-rust/issues/3

## Notes

[ @mentions for anyone who should be alerted to this PR ]

[ **Please assign reviewers if you want someone specific to review this** ]

[ **Please do not forget to add labels specific to this PR** ]
