### PR TITLE
Fix linker issues #2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,4 +76,4 @@ optimize_crc32_sse_v4s3x3 = []
 
 [lints.rust]
 # build-time feature enablement
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(optimized_crc32_iscsi)','cfg(optimized_crc32_iso_hdlc)' ] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(optimized_crc32_iscsi)','cfg(optimized_crc32_iso_hdlc)','cfg(rust_implementation_only)'] }

--- a/src/bindings/mod.rs
+++ b/src/bindings/mod.rs
@@ -11,10 +11,13 @@ use crate::structs::CrcParams;
 use std::ffi::CStr;
 use std::os::raw::c_char;
 
+#[cfg(not(rust_implementation_only))]
 mod crc32_iscsi;
+#[cfg(not(rust_implementation_only))]
 mod crc32_iso_hdlc;
 
 // note that the initial state needs to be reversed
+#[cfg(not(rust_implementation_only))]
 #[inline(always)]
 pub(crate) fn crc32_iso_hdlc(state: u64, data: &[u8], params: CrcParams) -> u64 {
     unsafe {
@@ -29,6 +32,7 @@ pub(crate) fn crc32_iso_hdlc(state: u64, data: &[u8], params: CrcParams) -> u64 
 }
 
 // note that the initial state needs to be reversed
+#[cfg(not(rust_implementation_only))]
 #[inline(always)]
 pub(crate) fn crc32_iscsi(state: u64, data: &[u8], params: CrcParams) -> u64 {
     unsafe {
@@ -39,11 +43,13 @@ pub(crate) fn crc32_iscsi(state: u64, data: &[u8], params: CrcParams) -> u64 {
     }
 }
 
+#[cfg(not(rust_implementation_only))]
 #[allow(unused)]
 pub unsafe fn get_iso_hdlc_target() -> String {
     convert_to_string(crc32_iso_hdlc::get_iso_hdlc_target())
 }
 
+#[cfg(not(rust_implementation_only))]
 #[allow(unused)]
 pub unsafe fn get_iscsi_target() -> String {
     convert_to_string(crc32_iscsi::get_iscsi_target())


### PR DESCRIPTION
## The Problem

This MR tries to fix #2 

## The Solution

I noticed that removing the bindings get rid of this linker errors.
Assuming we dont need those bindings if we have native codepath running we can use a cfg which is set in `build.rs` and consumed on compiling to disable those.

### Changes

We are removing the bindings if they are not used because they can cause problems. Idk if this is a problem

### Planned version bump

As the bindings did not belong to the external api we might make this a bugfix or ? if bindings where external we might need to make this a breaking change.

### Links

#2 
