### PR TITLE
Implement hardware accelerated XOR3 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,9 @@ alloc = []
 # enable VPCLMULQDQ support in Rust for x86_64 using nightly toolchain builds
 vpclmulqdq = []
 
+# enable AVX512 support in Rust for x86_64 using nightly toolchain builds
+avx512 = []
+
 # enable using fast-crc32 optimized C implementations for CRC-32/ISCSI and CRC-32/ISO-HDLC, automatically detected
 optimize_crc32_auto = []
 

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -325,7 +325,7 @@ where
 unsafe fn fold_and_xor<T: ArchOps, W: EnhancedCrcWidth>(
     current: T::Vector,
     coefficient: T::Vector,
-    new_data: T::Vector,
+    data_to_xor: T::Vector,
     reflected: bool,
     ops: &T,
 ) -> T::Vector
@@ -339,7 +339,7 @@ where
     };
 
     // Fold 16 bytes using width-specific method
-    W::fold_16(&mut temp_state, coefficient, new_data, ops);
+    W::fold_16(&mut temp_state, coefficient, data_to_xor, ops);
 
     temp_state.value
 }

--- a/src/arch/vpclmulqdq.rs
+++ b/src/arch/vpclmulqdq.rs
@@ -192,7 +192,7 @@ impl VpclmulqdqOps {
 
     /// Fold from 4 x 256-bit to 1 x 128-bit
     #[inline]
-    #[target_feature(enable = "avx2,sse2,sse4.1,pclmulqdq")]
+    #[target_feature(enable = "avx2,sse2,sse4.1,pclmulqdq,avx512f,avx512vl,vpclmulqdq")]
     unsafe fn fold_from_256_to_128(
         &self,
         x: [Simd256; 4],
@@ -242,7 +242,7 @@ impl VpclmulqdqOps {
             // Fold and XOR
             let folded = self.carryless_mul_00(v128[i], fold_coefficients[i]);
             let folded2 = self.carryless_mul_11(v128[i], fold_coefficients[i]);
-            acc = self.xor_vectors(acc, self.xor_vectors(folded, folded2));
+            acc = self.xor3_vectors(acc, folded, folded2);
         }
 
         acc

--- a/src/arch/vpclmulqdq.rs
+++ b/src/arch/vpclmulqdq.rs
@@ -38,12 +38,12 @@ impl Simd256 {
 
     #[inline]
     #[target_feature(enable = "avx2,avx512f,avx512vl,vpclmulqdq")]
-    unsafe fn fold_32(&self, coeff: &Self, new_data: &Self) -> Self {
+    unsafe fn fold_32(&self, coeff: &Self, data_to_xor: &Self) -> Self {
         // XOR3
         Self(_mm256_ternarylogic_epi64(
             _mm256_clmulepi64_epi128(self.0, coeff.0, 0x00),
             _mm256_clmulepi64_epi128(self.0, coeff.0, 0x11),
-            new_data.0,
+            data_to_xor.0,
             0x96,
         ))
     }

--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -244,7 +244,9 @@ impl ArchOps for X86Ops {
     ) -> Self::Vector {
         #[cfg(any(feature = "vpclmulqdq", feature = "avx512"))]
         if is_x86_feature_detected!("avx512f") && is_x86_feature_detected!("avx512vl") {
-            return _mm_ternarylogic_epi64(a, b, c, 0x96);
+            return _mm_ternarylogic_epi64(
+                a, b, c, 0x96, // XOR3
+            );
         }
 
         // x86 doesn't have native XOR3 in SSE, use two XORs

--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -226,6 +226,30 @@ impl ArchOps for X86Ops {
     unsafe fn carryless_mul_11(&self, a: Self::Vector, b: Self::Vector) -> Self::Vector {
         _mm_clmulepi64_si128(a, b, 0x11)
     }
+
+    #[inline]
+    #[cfg_attr(
+        any(feature = "vpclmulqdq", feature = "avx512"),
+        target_feature(enable = "avx512f,avx512vl")
+    )]
+    #[cfg_attr(
+        all(not(feature = "vpclmulqdq"), not(feature = "avx512")),
+        target_feature(enable = "sse2,sse4.1")
+    )]
+    unsafe fn xor3_vectors(
+        &self,
+        a: Self::Vector,
+        b: Self::Vector,
+        c: Self::Vector,
+    ) -> Self::Vector {
+        #[cfg(any(feature = "vpclmulqdq", feature = "avx512"))]
+        if is_x86_feature_detected!("avx512f") && is_x86_feature_detected!("avx512vl") {
+            return _mm_ternarylogic_epi64(a, b, c, 0x96);
+        }
+
+        // x86 doesn't have native XOR3 in SSE, use two XORs
+        _mm_xor_si128(_mm_xor_si128(a, b), c)
+    }
 }
 
 impl X86Ops {

--- a/src/crc32/algorithm.rs
+++ b/src/crc32/algorithm.rs
@@ -79,7 +79,7 @@ impl EnhancedCrcWidth for crate::structs::Width32 {
     unsafe fn fold_16<T: ArchOps>(
         state: &mut CrcState<T::Vector>,
         coeff: T::Vector,
-        new_data: T::Vector,
+        data_to_xor: T::Vector,
         ops: &T,
     ) where
         T::Vector: Copy,
@@ -99,7 +99,7 @@ impl EnhancedCrcWidth for crate::structs::Width32 {
             )
         };
 
-        state.value = ops.xor3_vectors(h, l, new_data);
+        state.value = ops.xor3_vectors(h, l, data_to_xor);
     }
 
     /// CRC-32 specific implementation for folding 8 bytes to 4 bytes

--- a/src/crc32/algorithm.rs
+++ b/src/crc32/algorithm.rs
@@ -76,8 +76,12 @@ impl EnhancedCrcWidth for crate::structs::Width32 {
     }
 
     #[inline(always)]
-    unsafe fn fold_16<T: ArchOps>(state: &mut CrcState<T::Vector>, coeff: T::Vector, ops: &T)
-    where
+    unsafe fn fold_16<T: ArchOps>(
+        state: &mut CrcState<T::Vector>,
+        coeff: T::Vector,
+        new_data: T::Vector,
+        ops: &T,
+    ) where
         T::Vector: Copy,
     {
         // For CRC-32, we need to handle the 32-bit sections of each 64-bit value
@@ -95,7 +99,7 @@ impl EnhancedCrcWidth for crate::structs::Width32 {
             )
         };
 
-        state.value = ops.xor_vectors(h, l);
+        state.value = ops.xor3_vectors(h, l, new_data);
     }
 
     /// CRC-32 specific implementation for folding 8 bytes to 4 bytes

--- a/src/crc64/algorithm.rs
+++ b/src/crc64/algorithm.rs
@@ -114,7 +114,7 @@ impl EnhancedCrcWidth for crate::structs::Width64 {
             let clmul1 = ops.carryless_mul_00(x, mu_poly);
             let clmul2 = ops.carryless_mul_10(clmul1, mu_poly);
             let clmul1_shifted = ops.shift_left_8(clmul1);
-            let final_xor = ops.xor_vectors(ops.xor_vectors(clmul2, clmul1_shifted), x);
+            let final_xor = ops.xor3_vectors(clmul2, clmul1_shifted, x);
 
             ops.extract_u64s(final_xor)[1]
         } else {

--- a/src/crc64/algorithm.rs
+++ b/src/crc64/algorithm.rs
@@ -57,15 +57,20 @@ impl EnhancedCrcWidth for crate::structs::Width64 {
     }
 
     #[inline(always)]
-    unsafe fn fold_16<T: ArchOps>(state: &mut CrcState<T::Vector>, coeff: T::Vector, ops: &T)
-    where
+    unsafe fn fold_16<T: ArchOps>(
+        state: &mut CrcState<T::Vector>,
+        coeff: T::Vector,
+        new_data: T::Vector,
+        ops: &T,
+    ) where
         T::Vector: Copy,
     {
         // CRC-64 specific implementation for folding 16 bytes
         state.value = {
-            ops.xor_vectors(
+            ops.xor3_vectors(
                 ops.carryless_mul_00(state.value, coeff),
                 ops.carryless_mul_11(state.value, coeff),
+                new_data,
             )
         };
     }

--- a/src/crc64/algorithm.rs
+++ b/src/crc64/algorithm.rs
@@ -60,7 +60,7 @@ impl EnhancedCrcWidth for crate::structs::Width64 {
     unsafe fn fold_16<T: ArchOps>(
         state: &mut CrcState<T::Vector>,
         coeff: T::Vector,
-        new_data: T::Vector,
+        data_to_xor: T::Vector,
         ops: &T,
     ) where
         T::Vector: Copy,
@@ -70,7 +70,7 @@ impl EnhancedCrcWidth for crate::structs::Width64 {
             ops.xor3_vectors(
                 ops.carryless_mul_00(state.value, coeff),
                 ops.carryless_mul_11(state.value, coeff),
-                new_data,
+                data_to_xor,
             )
         };
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,10 +105,10 @@
 //! assert_eq!(checksum.unwrap(), 0xcbf43926);
 //! ```
 
-// if VPCLMULQDQ is enabled, enable extra AVX512 features
+// if VPCLMULQDQ or AVX512 is enabled, enable extra AVX512 features
 #![cfg_attr(
-    feature = "vpclmulqdq",
-    feature(avx512_target_feature, stdarch_x86_avx512)
+    any(feature = "vpclmulqdq", feature = "avx512"),
+    feature(stdarch_x86_avx512)
 )]
 
 use crate::crc32::consts::{

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -221,6 +221,15 @@ pub trait ArchOps: Sized + Copy + Clone {
 
     /// Perform carryless multiplication with immediate value 0x11 (high 64 bits of both vectors)
     unsafe fn carryless_mul_11(&self, a: Self::Vector, b: Self::Vector) -> Self::Vector;
+
+    /// XOR three vectors together: a XOR b XOR c
+    /// Uses native XOR3 instructions when available, falls back to two XOR operations otherwise
+    unsafe fn xor3_vectors(
+        &self,
+        a: Self::Vector,
+        b: Self::Vector,
+        c: Self::Vector,
+    ) -> Self::Vector;
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
@@ -247,9 +256,13 @@ pub trait EnhancedCrcWidth: CrcWidth {
     where
         T::Vector: Copy;
 
-    /// Perform width-specific folding operations
-    unsafe fn fold_16<T: ArchOps>(state: &mut CrcState<T::Vector>, coefficient: T::Vector, ops: &T)
-    where
+    /// Perform width-specific folding operations using CLMUL and two XOR operations (or one XOR3)
+    unsafe fn fold_16<T: ArchOps>(
+        state: &mut CrcState<T::Vector>,
+        coefficient: T::Vector,
+        new_data: T::Vector,
+        ops: &T,
+    ) where
         T::Vector: Copy;
 
     /// Fold width-specific number of bytes

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -260,7 +260,7 @@ pub trait EnhancedCrcWidth: CrcWidth {
     unsafe fn fold_16<T: ArchOps>(
         state: &mut CrcState<T::Vector>,
         coefficient: T::Vector,
-        new_data: T::Vector,
+        data_to_xor: T::Vector,
         ops: &T,
     ) where
         T::Vector: Copy;


### PR DESCRIPTION
## The Problem

Modern processors often have support for three-way exclusive OR intrinsics (XOR3), which we're not using.

## The Solution

Use hardware accelerated XOR3 operations when possible on both Aarch64 and X86_64. Fallback to double XOR as usual when not.

### Planned version bump

- Which: `PATCH`
- Why: non-breaking performance optimization

### Links

* [Arm veor3q_u8](https://developer.arm.com/architectures/instruction-sets/intrinsics/veor3q_u8)
* [Intel _mm_ternarylogic_epi64](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_ternarylogic_epi64&expand=5870&ig_expand=6782)
* [Intel _mm256_ternarylogic_epi64](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_ternarylogic_epi64&expand=5873&ig_expand=6785) 

## Notes

Provides a small, but measurable, performance boost. 💪 