### PR TITLE
Improve VPCLMULQDQ to use 512-bit wide registers

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,14 +297,14 @@ AKA `crc32` in many, but not all, implementations.
 
 ### CRC-64/NVME
 
-| Arch    | Brand | CPU             | System                    | Target          | 1KiB (GiB/s) | 1MiB (GiB/s) |
-|:--------|:------|:----------------|:--------------------------|:----------------|-------------:|-------------:|
-| x86_64  | Intel | Sapphire Rapids | EC2 c7i.metal-48xl        | avx2_vpclmulqdq |        ~17.0 |        ~56.4 |
-| x86_64  | AMD   | Genoa           | EC2 c7a.metal-48xl        | avx2_vpclmulqdq |        ~17.3 |        ~27.4 |
-| aarch64 | AWS   | Graviton4       | EC2 c8g.metal-48xl        | neon_pclmulqdq  |        ~16.3 |        ~16.3 |
-| aarch64 | Apple | M3 Ultra        | Mac Studio (32 core)      | neon_pclmulqdq  |        ~44.0 |        ~71.9 |
-| aarch64 | Apple | M4 Max          | MacBook Pro 16" (16 core) | neon_pclmulqdq  |        ~40.3 |        ~72.3 | 
-| aarch64 | Apple | M2 Ultra        | Mac Studio (24 core)      | neon_pclmulqdq  |        ~39.3 |        ~65.0 |
+| Arch    | Brand | CPU             | System                    | Target            | 1KiB (GiB/s) | 1MiB (GiB/s) |
+|:--------|:------|:----------------|:--------------------------|:------------------|-------------:|-------------:|
+| x86_64  | Intel | Sapphire Rapids | EC2 c7i.metal-48xl        | avx512_vpclmulqdq |        ~20.3 |        ~94.1 |
+| x86_64  | AMD   | Genoa           | EC2 c7a.metal-48xl        | avx512_vpclmulqdq |        ~18.3 |        ~53.9 |
+| aarch64 | AWS   | Graviton4       | EC2 c8g.metal-48xl        | neon_pclmulqdq    |        ~16.3 |        ~16.3 |
+| aarch64 | Apple | M3 Ultra        | Mac Studio (32 core)      | neon_pclmulqdq    |        ~44.0 |        ~71.9 |
+| aarch64 | Apple | M4 Max          | MacBook Pro 16" (16 core) | neon_pclmulqdq    |        ~40.3 |        ~72.3 | 
+| aarch64 | Apple | M2 Ultra        | Mac Studio (24 core)      | neon_pclmulqdq    |        ~39.3 |        ~65.0 |
 
 ## Other CRC widths
 

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -145,7 +145,9 @@ where
         }
 
         // try to use the enhanced SIMD implementation first, fall back to non-enhanced if necessary
-        if !ops.process_enhanced_simd_blocks::<W>(state, first, rest, &reflector, keys) {
+        if rest.is_empty()
+            || !ops.process_enhanced_simd_blocks::<W>(state, first, rest, &reflector, keys)
+        {
             process_simd_chunks::<T, W>(state, first, rest, &reflector, keys, ops);
         }
 

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -90,7 +90,7 @@ unsafe fn process_by_strategy<T: ArchOps, W: EnhancedCrcWidth>(
     data: &[u8],
     state: &mut CrcState<T::Vector>,
     reflector: Reflector<T::Vector>,
-    keys: [u64; 21],
+    keys: [u64; 23],
     ops: &T,
 ) -> W::Value
 where
@@ -125,7 +125,7 @@ unsafe fn process_large_aligned<T: ArchOps, W: EnhancedCrcWidth>(
     bytes: &[u8],
     state: &mut CrcState<T::Vector>,
     reflector: Reflector<T::Vector>,
-    keys: [u64; 21],
+    keys: [u64; 23],
     ops: &T,
 ) -> W::Value
 where
@@ -177,7 +177,7 @@ unsafe fn process_simd_chunks<T: ArchOps, W: EnhancedCrcWidth>(
     first: &[T::Vector; 8],
     rest: &[[T::Vector; 8]],
     reflector: &Reflector<T::Vector>,
-    keys: [u64; 21],
+    keys: [u64; 23],
     ops: &T,
 ) where
     T::Vector: Copy,
@@ -256,7 +256,7 @@ unsafe fn process_exactly_16<T: ArchOps, W: EnhancedCrcWidth>(
     data: &[u8],
     state: &mut CrcState<T::Vector>,
     reflector: &Reflector<T::Vector>,
-    keys: [u64; 21],
+    keys: [u64; 23],
     ops: &T,
 ) -> W::Value
 where
@@ -356,7 +356,7 @@ unsafe fn process_17_to_31<T: ArchOps, W: EnhancedCrcWidth>(
     data: &[u8],
     state: &mut CrcState<T::Vector>,
     reflector: &Reflector<T::Vector>,
-    keys: [u64; 21],
+    keys: [u64; 23],
     ops: &T,
 ) -> W::Value
 where
@@ -395,7 +395,7 @@ unsafe fn process_32_to_255<T: ArchOps, W: EnhancedCrcWidth>(
     data: &[u8],
     state: &mut CrcState<T::Vector>,
     reflector: &Reflector<T::Vector>,
-    keys: [u64; 21],
+    keys: [u64; 23],
     ops: &T,
 ) -> W::Value
 where
@@ -457,7 +457,7 @@ unsafe fn get_last_two_xmms<T: ArchOps, W: EnhancedCrcWidth>(
     data: &[u8],
     remaining_len: usize,
     current_state: T::Vector,
-    keys: [u64; 21],
+    keys: [u64; 23],
     reflector: &Reflector<T::Vector>,
     reflected: bool,
     ops: &T,

--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -90,7 +90,7 @@ impl ArchOps for X86Ops {
     }
 
     #[inline]
-    #[target_feature(enable = "sse2,sse4.1")]
+    #[target_feature(enable = "sse2,sse4.1,ssse3")]
     unsafe fn shuffle_bytes(&self, data: Self::Vector, mask: Self::Vector) -> Self::Vector {
         // x86 uses specific SSSE3 instruction
         _mm_shuffle_epi8(data, mask)

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -43,54 +43,6 @@ pub const CRC_64_NVME: Algorithm<u64> = Algorithm {
     residue: 0xf310303b2b6f6e42,
 };
 
-pub(crate) const CRC32_EXPONENTS: [u64; 21] = [
-    0, // unused, just aligns indexes with the literature
-    32 * 3,
-    32 * 5,
-    32 * 31,
-    32 * 33,
-    32 * 3,
-    32 * 2,
-    0, // mu, generate separately
-    0, // poly, generate separately
-    32 * 27,
-    32 * 29,
-    32 * 23,
-    32 * 25,
-    32 * 19,
-    32 * 21,
-    32 * 15,
-    32 * 17,
-    32 * 11,
-    32 * 13,
-    32 * 7,
-    32 * 9,
-];
-
-pub(crate) const CRC64_EXPONENTS: [u64; 21] = [
-    0, // unused, just aligns indexes with the literature
-    64 * 2,
-    64 * 3,
-    64 * 16,
-    64 * 17,
-    64 * 2,
-    64,
-    0, // mu, generate separately
-    0, // poly, generate separately
-    64 * 14,
-    64 * 15,
-    64 * 12,
-    64 * 13,
-    64 * 10,
-    64 * 11,
-    64 * 8,
-    64 * 9,
-    64 * 6,
-    64 * 7,
-    64 * 4,
-    64 * 5,
-];
-
 // for software fallbacks and testing
 pub(crate) const RUST_CRC32_AIXM: crc::Crc<u32> = crc::Crc::<u32>::new(&crc::CRC_32_AIXM);
 

--- a/src/crc32/algorithm.rs
+++ b/src/crc32/algorithm.rs
@@ -188,7 +188,7 @@ impl EnhancedCrcWidth for crate::structs::Width32 {
     unsafe fn perform_final_reduction<T: ArchOps>(
         state: T::Vector,
         reflected: bool,
-        keys: [u64; 21],
+        keys: [u64; 23],
         ops: &T,
     ) -> Self::Value
     where
@@ -237,7 +237,7 @@ pub(crate) unsafe fn process_0_to_15<T: ArchOps, W: EnhancedCrcWidth>(
     data: &[u8],
     state: &mut CrcState<T::Vector>,
     reflector: &Reflector<T::Vector>,
-    keys: [u64; 21],
+    keys: [u64; 23],
     ops: &T,
 ) -> W::Value
 where

--- a/src/crc32/consts.rs
+++ b/src/crc32/consts.rs
@@ -183,7 +183,7 @@ pub const CRC32_XFER: CrcParams = CrcParams {
 };
 
 // CRC-32/AIXM
-pub const KEYS_814141AB_FORWARD: [u64; 21] = [
+pub const KEYS_814141AB_FORWARD: [u64; 23] = [
     0x0000000000000000,
     0x9be9878f00000000,
     0x85b2a6e400000000,
@@ -205,10 +205,12 @@ pub const KEYS_814141AB_FORWARD: [u64; 21] = [
     0x361f380200000000,
     0x6757ee2f00000000,
     0xffc42e7700000000,
+    0xd12a88300000000,
+    0x93a03b8800000000,
 ];
 
 // CRC-32/AUTOSAR
-pub const KEYS_F4ACFB13_REFLECTED: [u64; 21] = [
+pub const KEYS_F4ACFB13_REFLECTED: [u64; 23] = [
     0x0000000000000000,
     0x000000016130902a,
     0x0000000050428a9c,
@@ -230,10 +232,12 @@ pub const KEYS_F4ACFB13_REFLECTED: [u64; 21] = [
     0x0000000049cb6c68,
     0x00000000c9d55d76,
     0x0000000022919656,
+    0x00000001e97b6a9e,
+    0x00000000000cbd7c,
 ];
 
 // CRC-32/BASE91-D
-pub const KEYS_A833982B_REFLECTED: [u64; 21] = [
+pub const KEYS_A833982B_REFLECTED: [u64; 23] = [
     0x0000000000000000,
     0x00000001e065d896,
     0x00000001aca6d990,
@@ -255,10 +259,12 @@ pub const KEYS_A833982B_REFLECTED: [u64; 21] = [
     0x00000001942367fa,
     0x00000000c2044564,
     0x00000001a07ba234,
+    0x000000010ffc58e6,
+    0x000000015920d7a6,
 ];
 
 // CRC-32/CD-ROM-EDC
-pub const KEYS_8001801B_REFLECTED: [u64; 21] = [
+pub const KEYS_8001801B_REFLECTED: [u64; 23] = [
     0x0000000000000000,
     0x00000001d5934102,
     0x000000006c90c100,
@@ -280,10 +286,12 @@ pub const KEYS_8001801B_REFLECTED: [u64; 21] = [
     0x00000001517f91c2,
     0x00000001f75a6182,
     0x00000000bd01c000,
+    0x00000001bcb30820,
+    0x000000010d925102,
 ];
 
 // CRC-32/MEF
-pub const KEYS_741B8CD7_REFLECTED: [u64; 21] = [
+pub const KEYS_741B8CD7_REFLECTED: [u64; 23] = [
     0x0000000000000000,
     0x000000014b0602f8,
     0x000000007b4bc878,
@@ -305,10 +313,12 @@ pub const KEYS_741B8CD7_REFLECTED: [u64; 21] = [
     0x0000000097259f1a,
     0x00000000adfa5198,
     0x000000009c899030,
+    0x00000001adf2908e,
+    0x00000001f91b48f0,
 ];
 
 // CRC-32/XFER
-pub const KEYS_000000AF_FORWARD: [u64; 21] = [
+pub const KEYS_000000AF_FORWARD: [u64; 23] = [
     0x0000000000000000,
     0x00295f2300000000,
     0xfafa517900000000,
@@ -330,10 +340,12 @@ pub const KEYS_000000AF_FORWARD: [u64; 21] = [
     0x784a483800000000,
     0x7d21bf2000000000,
     0xfaebd3d300000000,
+    0x25ed382b00000000,
+    0x6d2b811a00000000,
 ];
 
 // CRC-32/ISO-HDLC (aka 'crc32'), CRC-32/JAMCRC
-const KEYS_04C11DB7_REFLECTED: [u64; 21] = [
+const KEYS_04C11DB7_REFLECTED: [u64; 23] = [
     0x0000000000000000, // unused placeholder to match 1-based indexing
     0x00000000ccaa009e, // (2^(32* 3) mod P(x))' << 1
     0x00000001751997d0, // (2^(32* 5) mod P(x))' << 1
@@ -355,10 +367,12 @@ const KEYS_04C11DB7_REFLECTED: [u64; 21] = [
     0x000000003db1ecdc, // (2^(32*13) mod P(x))' << 1
     0x000000015a546366, // (2^(32* 7) mod P(x))' << 1
     0x00000000f1da05aa, // (2^(32* 9) mod P(x))' << 1
+    0x00000001322d1430,
+    0x000000011542778a,
 ];
 
 // CRC-32/ISCSI (aka 'crc32c')
-const KEYS_1EDC6F41_REFLECTED: [u64; 21] = [
+const KEYS_1EDC6F41_REFLECTED: [u64; 23] = [
     0x0000000000000000, // unused placeholder to match 1-based indexing
     0x000000014cd00bd6, // (2^(32* 3) mod P(x))' << 1
     0x00000000f20c0dfe, // (2^(32* 5) mod P(x))' << 1
@@ -380,10 +394,12 @@ const KEYS_1EDC6F41_REFLECTED: [u64; 21] = [
     0x000000001c291d04, // (2^(32*13) mod P(x))' << 1
     0x00000000ba4fc28e, // (2^(32* 7) mod P(x))' << 1
     0x00000001384aa63a, // (2^(32* 9) mod P(x))' << 1
+    0x00000000b9e02b86,
+    0x00000000dcb17aa4,
 ];
 
 // CRC-32/BZIP2, CRC-32/CKSUM, CRC-32/MPEG-2
-const KEYS_04C11DB7_FORWARD: [u64; 21] = [
+const KEYS_04C11DB7_FORWARD: [u64; 23] = [
     0x0000000000000000, // unused placeholder to match 1-based indexing
     0xf200aa6600000000, // 2^(32* 3) mod P(x) << 32
     0x17d3315d00000000, // 2^(32* 5) mod P(x) << 32
@@ -405,6 +421,8 @@ const KEYS_04C11DB7_FORWARD: [u64; 21] = [
     0x766f1b7800000000, // 2^(32*13) mod P(x) << 32
     0xcd8c54b500000000, // 2^(32* 7) mod P(x) << 32
     0xab40b71e00000000, // 2^(32* 9) mod P(x) << 32
+    0x1851689900000000,
+    0xa3dc855100000000,
 ];
 
 pub(crate) const SIMD_CONSTANTS: [[u64; 2]; 4] = [

--- a/src/crc64/algorithm.rs
+++ b/src/crc64/algorithm.rs
@@ -146,7 +146,7 @@ impl EnhancedCrcWidth for crate::structs::Width64 {
     unsafe fn perform_final_reduction<T: ArchOps>(
         state: T::Vector,
         reflected: bool,
-        keys: [u64; 21],
+        keys: [u64; 23],
         ops: &T,
     ) -> Self::Value
     where
@@ -213,7 +213,7 @@ pub(crate) unsafe fn process_0_to_15<T: ArchOps, W: EnhancedCrcWidth>(
     data: &[u8],
     state: &mut CrcState<T::Vector>,
     reflector: &Reflector<T::Vector>,
-    keys: [u64; 21],
+    keys: [u64; 23],
     ops: &T,
 ) -> W::Value
 where

--- a/src/crc64/consts.rs
+++ b/src/crc64/consts.rs
@@ -18,7 +18,7 @@ pub const CRC64_ECMA_182: CrcParams = CrcParams {
     refout: CRC_64_ECMA_182.refout, // false
     xorout: CRC_64_ECMA_182.xorout,
     check: CRC_64_ECMA_182.check,
-    keys: KEYS_FORWARD_42F0E1EBA9EA3693,
+    keys: KEYS_42F0E1EBA9EA3693_FORWARD,
 };
 
 // width=64 poly=0x000000000000001b init=0xffffffffffffffff refin=true refout=true xorout=0xffffffffffffffff check=0xb90956c775a41001 residue=0x5300000000000000 name="CRC-64/GO-ISO"
@@ -32,7 +32,7 @@ pub const CRC64_GO_ISO: CrcParams = CrcParams {
     refout: CRC_64_GO_ISO.refout, // true
     xorout: CRC_64_GO_ISO.xorout,
     check: CRC_64_GO_ISO.check,
-    keys: KEYS_REVERSE_000000000000001B,
+    keys: KEYS_000000000000001B_REFLECTED,
 };
 
 // width=64 poly=0x259c84cba6426349 init=0xffffffffffffffff refin=true refout=true xorout=0x0000000000000000 check=0x75d4b74f024eceea residue=0x0000000000000000 name="CRC-64/MS"
@@ -46,7 +46,7 @@ pub const CRC64_MS: CrcParams = CrcParams {
     refout: CRC_64_MS.refout, // true
     xorout: CRC_64_MS.xorout,
     check: CRC_64_MS.check,
-    keys: KEYS_REVERSE_259C84CBA6426349,
+    keys: KEYS_259C84CBA6426349_REFLECTED,
 };
 
 // https://reveng.sourceforge.io/crc-catalogue/all.htm#crc.cat.crc-64-nvme
@@ -61,7 +61,7 @@ pub const CRC64_NVME: CrcParams = CrcParams {
     refout: CRC_64_NVME.refout, // true
     xorout: CRC_64_NVME.xorout,
     check: CRC_64_NVME.check,
-    keys: KEYS_REVERSE_AD93D23594C93659,
+    keys: KEYS_AD93D23594C93659_REFLECTED,
 };
 
 // width=64 poly=0xad93d23594c935a9 init=0x0000000000000000 refin=true refout=true xorout=0x0000000000000000 check=0xe9c6d914c4b8d9ca residue=0x0000000000000000 name="CRC-64/REDIS"
@@ -75,7 +75,7 @@ pub const CRC64_REDIS: CrcParams = CrcParams {
     refout: CRC_64_REDIS.refout, // true
     xorout: CRC_64_REDIS.xorout,
     check: CRC_64_REDIS.check,
-    keys: KEYS_REVERSE_AD93D23594C935A9,
+    keys: KEYS_AD93D23594C935A9_REFLECTED,
 };
 
 // width=64 poly=0x42f0e1eba9ea3693 init=0xffffffffffffffff refin=false refout=false xorout=0xffffffffffffffff check=0x62ec59e3f1a4f00a residue=0xfcacbebd5931a992 name="CRC-64/WE"
@@ -89,7 +89,7 @@ pub const CRC64_WE: CrcParams = CrcParams {
     refout: CRC_64_WE.refout, // false
     xorout: CRC_64_WE.xorout,
     check: CRC_64_WE.check,
-    keys: KEYS_FORWARD_42F0E1EBA9EA3693,
+    keys: KEYS_42F0E1EBA9EA3693_FORWARD,
 };
 
 // width=64 poly=0x42f0e1eba9ea3693 init=0xffffffffffffffff refin=true refout=true xorout=0xffffffffffffffff check=0x995dc9bbdf1939fa residue=0x49958c9abd7d353f name="CRC-64/XZ"
@@ -103,11 +103,11 @@ pub const CRC64_XZ: CrcParams = CrcParams {
     refout: CRC_64_XZ.refout, // true
     xorout: CRC_64_XZ.xorout,
     check: CRC_64_XZ.check,
-    keys: KEYS_REVERSE_42F0E1EBA9EA3693,
+    keys: KEYS_42F0E1EBA9EA3693_REFLECTED,
 };
 
 // CRC-64/MS
-const KEYS_REVERSE_259C84CBA6426349: [u64; 21] = [
+const KEYS_259C84CBA6426349_REFLECTED: [u64; 23] = [
     0x0000000000000000,
     0xcef05cca14bbf4df,
     0xfd5d7a0700b5ba38,
@@ -129,10 +129,12 @@ const KEYS_REVERSE_259C84CBA6426349: [u64; 21] = [
     0x717984ed338c465f,
     0x70bd522114faceb8,
     0x2188097f5687b43c,
+    0xb7c2f9fa47c4fe55,
+    0x8dccaf9d6169d0fa,
 ];
 
 // CRC-64/REDIS
-const KEYS_REVERSE_AD93D23594C935A9: [u64; 21] = [
+const KEYS_AD93D23594C935A9_REFLECTED: [u64; 23] = [
     0x0000000000000000,
     0x381d0015c96f4444,
     0xd9d7be7d505da32c,
@@ -154,10 +156,12 @@ const KEYS_REVERSE_AD93D23594C935A9: [u64; 21] = [
     0xa062b2319d66692f,
     0xef3d1d18ed889ed2,
     0x6ba4d760ab38201e,
+    0x9471a5389095fe44,
+    0x9a8908341a6d6d52,
 ];
 
 // CRC-64/ECMA-182, CRC-64/WE
-const KEYS_FORWARD_42F0E1EBA9EA3693: [u64; 21] = [
+const KEYS_42F0E1EBA9EA3693_FORWARD: [u64; 23] = [
     0x0000000000000000, // unused placeholder to match 1-based indexing
     0x05f5c3c7eb52fab6, // 2^(64* 2) mod P(x)
     0x4eb938a7d257740e, // 2^(64* 3) mod P(x)
@@ -179,10 +183,12 @@ const KEYS_FORWARD_42F0E1EBA9EA3693: [u64; 21] = [
     0x4a6b90073eb0af5a, // 2^(64* 7) mod P(x)
     0x571bee0a227ef92b, // 2^(64* 4) mod P(x)
     0x44bef2a201b5200c, // 2^(64* 5) mod P(x)
+    0x7f52691a60ddc70d,
+    0x7036b0389f6a0c82,
 ];
 
 // CRC-64/XZ
-const KEYS_REVERSE_42F0E1EBA9EA3693: [u64; 21] = [
+const KEYS_42F0E1EBA9EA3693_REFLECTED: [u64; 23] = [
     0x0000000000000000, // unused placeholder to match 1-based indexing
     0xdabe95afc7875f40, // 2^((64* 2)-1) mod P(x)
     0xe05dd497ca393ae4, // 2^((64* 3)-1) mod P(x)
@@ -204,10 +210,12 @@ const KEYS_REVERSE_42F0E1EBA9EA3693: [u64; 21] = [
     0xb5ea1af9c013aca4, // 2^((64* 7)-1) mod P(x)
     0x3be653a30fe1af51, // 2^((64* 4)-1) mod P(x)
     0x60095b008a9efa44, // 2^((64* 5)-1) mod P(x)
+    0xf31fd9271e228b79,
+    0x8260adf2381ad81c,
 ];
 
 // CRC-64/GO-ISO
-const KEYS_REVERSE_000000000000001B: [u64; 21] = [
+const KEYS_000000000000001B_REFLECTED: [u64; 23] = [
     0x0000000000000000, // unused placeholder to match 1-based indexing
     0xf500000000000001, // 2^((64* 2)-1) mod P(x)
     0x6b70000000000001, // 2^((64* 3)-1) mod P(x)
@@ -229,10 +237,12 @@ const KEYS_REVERSE_000000000000001B: [u64; 21] = [
     0x76db6c7000000001, // 2^((64* 7)-1) mod P(x)
     0xa011000000000001, // 2^((64* 4)-1) mod P(x)
     0x1b1ab00000000001, // 2^((64* 5)-1) mod P(x)
+    0x45000000b0000000,
+    0x6b700000f5000000,
 ];
 
 // CRC-64/NVME
-const KEYS_REVERSE_AD93D23594C93659: [u64; 21] = [
+const KEYS_AD93D23594C93659_REFLECTED: [u64; 23] = [
     0x0000000000000000, // unused placeholder to match 1-based indexing
     0x21e9_761e_2526_21ac,
     0xeadc_41fd_2ba3_d420,
@@ -254,6 +264,8 @@ const KEYS_REVERSE_AD93D23594C93659: [u64; 21] = [
     0xbdd7_ac0e_e1a4_a0f0,
     0xe1e0_bb9d_45d7_a44c,
     0xb0bc_2e58_9204_f500,
+    0xa043_808c_0f78_2663,
+    0x37cc_d3e1_4069_cabc,
 ];
 
 pub const SIMD_CONSTANTS: [[u64; 2]; 4] = [

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -4,13 +4,64 @@
 
 #![allow(dead_code)]
 
-use crate::consts::{CRC32_EXPONENTS, CRC64_EXPONENTS};
 use std::ops::{BitAnd, BitOr, Shl, Shr};
+
+const CRC32_EXPONENTS: [u64; 23] = [
+    0, // unused, just aligns indexes with the literature
+    32 * 3,
+    32 * 5,
+    32 * 31,
+    32 * 33,
+    32 * 3,
+    32 * 2,
+    0, // mu, generate separately
+    0, // poly, generate separately
+    32 * 27,
+    32 * 29,
+    32 * 23,
+    32 * 25,
+    32 * 19,
+    32 * 21,
+    32 * 15,
+    32 * 17,
+    32 * 11,
+    32 * 13,
+    32 * 7,
+    32 * 9,
+    32 * 63, // for 256 byte distances (2048 - 32)
+    32 * 65, // for 256 byte distances (2048 + 32)
+];
+
+const CRC64_EXPONENTS: [u64; 23] = [
+    0, // unused, just aligns indexes with the literature
+    64 * 2,
+    64 * 3,
+    64 * 16,
+    64 * 17,
+    64 * 2,
+    64,
+    0, // mu, generate separately
+    0, // poly, generate separately
+    64 * 14,
+    64 * 15,
+    64 * 12,
+    64 * 13,
+    64 * 10,
+    64 * 11,
+    64 * 8,
+    64 * 9,
+    64 * 6,
+    64 * 7,
+    64 * 4,
+    64 * 5,
+    64 * 32, // for 256 byte distances (2048)
+    64 * 33, // for 256 byte distances (2048 + 64)
+];
 
 /// Generates the 20 keys needed to calculate CRCs for a given polynomial using PCLMULQDQ when
 /// folding by 8.
-pub(crate) fn keys(width: u8, poly: u64, reflected: bool) -> [u64; 21] {
-    let mut keys: [u64; 21] = [0; 21];
+pub fn keys(width: u8, poly: u64, reflected: bool) -> [u64; 23] {
+    let mut keys: [u64; 23] = [0; 23];
 
     let exponents = if 32 == width {
         CRC32_EXPONENTS
@@ -26,7 +77,7 @@ pub(crate) fn keys(width: u8, poly: u64, reflected: bool) -> [u64; 21] {
         poly
     };
 
-    for i in 1..21 {
+    for i in 1..23 {
         keys[i] = key(width, poly, reflected, exponents[i]);
     }
 

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -17,7 +17,7 @@ pub struct CrcParams {
     pub refout: bool,
     pub xorout: u64,
     pub check: u64,
-    pub keys: [u64; 21],
+    pub keys: [u64; 23],
 }
 
 /// CRC-32 width implementation

--- a/src/test/enums.rs
+++ b/src/test/enums.rs
@@ -53,7 +53,7 @@ impl AnyCrcTestConfig {
         self.get_params().name
     }
 
-    pub fn get_keys(&self) -> [u64; 21] {
+    pub fn get_keys(&self) -> [u64; 23] {
         self.get_params().keys
     }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -48,7 +48,7 @@ pub trait ArchOps: Sized + Copy + Clone {
         _first: &[Self::Vector; 8],
         _rest: &[[Self::Vector; 8]],
         _reflector: &Reflector<Self::Vector>,
-        _keys: [u64; 21],
+        _keys: [u64; 23],
     ) -> bool
     where
         Self::Vector: Copy,
@@ -294,7 +294,7 @@ pub trait EnhancedCrcWidth: CrcWidth {
     unsafe fn perform_final_reduction<T: ArchOps>(
         state: T::Vector,
         reflected: bool,
-        keys: [u64; 21],
+        keys: [u64; 23],
         ops: &T,
     ) -> Self::Value
     where


### PR DESCRIPTION
## The Problem

The current implementation uses 4 x 256-bit registers, but modern VPCLMULQDQ CPUs support 512-bit operations, which should be faster.

## The Solution

Implement 4 x 512-bit operations for increased throughput. CRC-64/NVME calculations went from ~56.4 GiB/s to ~96.1 GiB/s on a Sapphire Rapids AWS EC c7i.8xlarge instance.

### Changes

- Calculate a new 256-byte distance folding coefficient for all CRC variants
- Update VPCLMULQDQ calculations to use 512-bit wide registers and intrinsics

### Planned version bump

- Which: `MINOR`
- Why: non-breaking new functionality (gated behind `nightly` and the `vpclmulqdq` feature flag)