### PR TITLE
Support custom crc parameters

### DIFF
--- a/libcrc_fast.h
+++ b/libcrc_fast.h
@@ -50,6 +50,21 @@ typedef struct CrcFastDigestHandle {
   struct CrcFastDigest *_0;
 } CrcFastDigestHandle;
 
+/**
+ * Custom CRC parameters
+ */
+typedef struct CrcFastParams {
+  enum CrcFastAlgorithm algorithm;
+  uint8_t width;
+  uint64_t poly;
+  uint64_t init;
+  bool refin;
+  bool refout;
+  uint64_t xorout;
+  uint64_t check;
+  uint64_t keys[23];
+} CrcFastParams;
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
@@ -58,6 +73,11 @@ extern "C" {
  * Creates a new Digest to compute CRC checksums using algorithm
  */
 struct CrcFastDigestHandle *crc_fast_digest_new(enum CrcFastAlgorithm algorithm);
+
+/**
+ * Creates a new Digest to compute CRC checksums using custom parameters
+ */
+struct CrcFastDigestHandle *crc_fast_digest_new_with_params(struct CrcFastParams params);
 
 /**
  * Updates the Digest with data
@@ -101,11 +121,25 @@ uint64_t crc_fast_digest_get_amount(struct CrcFastDigestHandle *handle);
 uint64_t crc_fast_checksum(enum CrcFastAlgorithm algorithm, const char *data, uintptr_t len);
 
 /**
+ * Helper method to calculate a CRC checksum directly for data using custom parameters
+ */
+uint64_t crc_fast_checksum_with_params(struct CrcFastParams params,
+                                       const char *data,
+                                       uintptr_t len);
+
+/**
  * Helper method to just calculate a CRC checksum directly for a file using algorithm
  */
 uint64_t crc_fast_checksum_file(enum CrcFastAlgorithm algorithm,
                                 const uint8_t *path_ptr,
                                 uintptr_t path_len);
+
+/**
+ * Helper method to calculate a CRC checksum directly for a file using custom parameters
+ */
+uint64_t crc_fast_checksum_file_with_params(struct CrcFastParams params,
+                                            const uint8_t *path_ptr,
+                                            uintptr_t path_len);
 
 /**
  * Combine two CRC checksums using algorithm


### PR DESCRIPTION
## The Problem

While the list of hardcoded supported CRC variants is comprehensive, covering [all the known CRC-32 and CRC-64 variants](https://reveng.sourceforge.io/crc-catalogue/all.htm), it may be useful to support arbitrary custom parameters for future or unknown variants.

## The Solution

Add support for custom CRC parameters.

### Changes

- Add functions to support Digest, checksum, and checksum_file operations using custom parameters.
- Add test coverage.
- Add support for the new functions in the C-compatible shared library as well.
 
### Planned version bump

- Which: `MINOR`
- Why: non-breaking new functionality

### Links

* https://github.com/awesomized/crc-fast-rust/issues/5 requested by @jg15