### PR TITLE
change unconditional x86-64-v4 reliance to the former x86-64-v2 reliance

### DIFF
--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -229,7 +229,7 @@ impl ArchOps for X86Ops {
 
     #[rustversion::since(1.89)]
     #[inline]
-    #[target_feature(enable = "avx512f,avx512vl")]
+    #[target_feature(enable = "sse4.1")]
     unsafe fn xor3_vectors(
         &self,
         a: Self::Vector,


### PR DESCRIPTION
This implements a fix that closes #14 (removing the unconditional enabling of avx512 features)

It should be noted during my cursory audit, I found this crate appears to hard baseline on x86-64-v2 (with sse4.1 being silently asserted), and there might also be hard baselines on neon+aes with aarch64

This violates typical expectations (that code will compile against target baselines and only enable features that have a positive is_X_feature_detected call) so either compile errors should be inserted if not compiling against those baselines (ala simd_json) or new polyfills/checks should be inserted for software implementation