### PR TITLE
Add support for building a static library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.81"
 
 [lib]
 name = "crc_fast"
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib", "cdylib", "staticlib"]
 bench = true
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ So I wrote one. :)
 
 ## Other languages
 
-Supplies a [C/C++ compatible shared library](#cc-compatible-shared-library) for use with other non-`Rust` languages.
+Supplies a [C/C++ compatible library](#cc-compatible-library) for use with other non-`Rust` languages.
 
 ## Implementations
 
@@ -39,8 +39,7 @@ See [CHANGELOG](CHANGELOG.md).
 ## Build & Install
 
 `cargo build` will obviously build the library, including
-the [C-compatible shared library](#c-compatible-shared-library). There are fine-tuning [feature flags](Cargo.toml)
-available, should they be necessary for your deployment and [acceleration](#acceleration-targets) targets.
+the [C-compatible library](#cc-compatible-library).
 
 A _very_ basic [Makefile](Makefile) is supplied which supports `make install` to install the shared library and header
 file to
@@ -248,11 +247,12 @@ let checksum = checksum_file_with_params(custom_params, file_on_disk, None);
 assert_eq!(checksum.unwrap(), 0xcbf43926);
 ```
 
-## C/C++ compatible shared library
+## C/C++ compatible library
 
 `cargo build` will produce a shared library target (`.so` on Linux, `.dll` on Windows, `.dylib` on macOS, etc) and an
 auto-generated [libcrc_fast.h](libcrc_fast.h) header file for use in non-Rust projects, such as through
-[FFI](https://en.wikipedia.org/wiki/Foreign_function_interface).
+[FFI](https://en.wikipedia.org/wiki/Foreign_function_interface). It will also produce a static library target (`.a` on Linux and macOS, `.lib` on Windows, etc) for projects
+which prefer statically linking.
 
 There is a [crc-fast PHP extension](https://github.com/awesomized/crc-fast-php-ext) using it, for example.
 


### PR DESCRIPTION
## The Problem

Some projects can't, or don't want to, link to a dynamic library.

## The Solution

Build both dynamic and static libraries, giving projects choice in how they adopt.

### Changes

- Adds `staticlib` to `Cargo.toml` 
 
### Planned version bump

- Which: `MINOR`
- Why: non-breaking new functionality