### PR TITLE
remove libc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,6 @@ dependencies = [
  "crc",
  "criterion",
  "digest",
- "libc",
  "rand",
  "regex",
  "rustversion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ bench = true
 crc = "3"
 digest = {  version = "0.10", features = ["alloc"] }
 rand = "0.9"
-libc = "0.2"
 regex = "1.11"
 rustversion = "1.0"
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -515,7 +515,7 @@ pub extern "C" fn crc_fast_get_calculator_target(algorithm: CrcFastAlgorithm) ->
 
 /// Gets the version of this library
 #[no_mangle]
-pub extern "C" fn crc_fast_get_version() -> *const libc::c_char {
+pub extern "C" fn crc_fast_get_version() -> *const c_char {
     const VERSION: &CStr =
         match CStr::from_bytes_with_nul(concat!(env!("CARGO_PKG_VERSION"), "\0").as_bytes()) {
             Ok(version) => version,


### PR DESCRIPTION
## The Problem

This library does not really depend on `libc`; it only uses `libc::c_char` once, which can be replaced with `std::os::raw::c_char`. I discovered this when trying to compile for a target that doesn't have libc.

## The Solution

Change `libc::c_char` to `c_char` and remove `libc = "0.2"` from `Cargo.toml`.
