### PR TITLE
Misc fixes for Debian

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ std = ["alloc"] # std implies alloc is available
 alloc = ["digest"] # marker feature for heap allocation support
 panic-handler = [] # Provides panic handler for no_std library checks (disable in binaries)
 ffi = [
+    "std"
 ] # C/C++ compatible dynamic/static library, planned to become optional in the next MAJOR version (v2) to reduce overhead
 
 # optional features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ crc = "3.4"
 criterion = "0.7"
 cbindgen = "0.29"
 proptest = "1.9"
-rand = "0.9"
+rand = "0.10"
 regex = "1.12"
 wasm-bindgen-test = "0.3"
 

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -187,7 +187,7 @@ mod tests {
     use crate::test::consts::{TEST_256_BYTES_STRING, TEST_ALL_CONFIGS, TEST_CHECK_STRING};
     use crate::test::create_aligned_data;
     use crate::test::enums::AnyCrcTestConfig;
-    use rand::{rng, Rng};
+    use rand::{rng, RngExt};
 
     #[test]
     fn test_check_value() {

--- a/src/crc32/fusion/aarch64/mod.rs
+++ b/src/crc32/fusion/aarch64/mod.rs
@@ -225,7 +225,7 @@ mod tests {
     use super::*;
     use crate::test::consts::TEST_CHECK_STRING;
     use crc::{Crc, Table};
-    use rand::{rng, Rng};
+    use rand::{rng, RngExt};
 
     const RUST_CRC32_ISO_HDLC: Crc<u32, Table<16>> =
         Crc::<u32, Table<16>>::new(&crc::CRC_32_ISO_HDLC);

--- a/src/crc32/fusion/x86/mod.rs
+++ b/src/crc32/fusion/x86/mod.rs
@@ -216,7 +216,7 @@ mod tests {
     use super::*;
     use crate::test::consts::TEST_CHECK_STRING;
     use crc::{Crc, Table};
-    use rand::{rng, Rng};
+    use rand::{rng, RngExt};
 
     const RUST_CRC32_ISCSI: Crc<u32, Table<16>> = Crc::<u32, Table<16>>::new(&crc::CRC_32_ISCSI);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1353,7 +1353,7 @@ mod lib {
     use crate::test::enums::AnyCrcTestConfig;
     use cbindgen::Language::C;
     use cbindgen::Style::Both;
-    use rand::{rng, Rng};
+    use rand::{rng, RngExt};
     use std::fs::{read, write};
 
     #[test]


### PR DESCRIPTION
## The Problem

Working on packaging `crc-fast` in Debian.

## The Solution

- Debian Testing already has `rand = 0.10.1`, so bump the dep and fix build/test failures
- Allow the tests to run with `--no-default-features --features ffi`

### Changes

debcargo automatically creates tests than run the test suite for each feature with all other features disabled. This fails for `ffi` since it doesn't pull in `std`. Since the function interface provided by the `.so` handles some file I/O for callers, it looks to me like `ffi` should depend on `std` (it fails to compile otherwise).

### Planned version bump

- Which: `PATCH` 
- Why: internal change

### Links

https://salsa.debian.org/rust-team/debcargo-conf/-/merge_requests/1152

## Notes

N/A
